### PR TITLE
Base for comments

### DIFF
--- a/comments/Comment.go
+++ b/comments/Comment.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"net/http"
+	"time"
+)
+
+type comment struct {
+	id       int        `json:"id"`
+	user     string     `json:"user"`
+	time     time.Stamp `json:"time"`
+	text     string     `json:"text"`
+	upvotes  int        `json:"upvotes"`
+	response int        `json:"response"`
+}
+
+func post(w http.ResponseWriter, r *http.Request) { //takes user id, token, text, response
+
+}
+
+func like(w http.ResponseWriter, r *http.Request) { //takes user id, token, post id
+
+}
+
+func delete(w http.ResponseWriter, r *http.Request) { //takes user id, token, post id
+
+}
+
+func get(w http.ResponseWriter, r *http.Request) { //takes user id, token, video
+	//fetch comments associated with video
+}

--- a/comments/SQL.go
+++ b/comments/SQL.go
@@ -1,0 +1,2 @@
+//handles SQL connection
+package main

--- a/comments/Self.go
+++ b/comments/Self.go
@@ -1,0 +1,24 @@
+package main
+
+//loosely based on the Jungian idea of the Self
+
+import (
+	"net/http"
+)
+
+func main() {
+	http.HandleFunc("/comment/post", func(w http.ResponseWriter, r *http.Request) {
+		post(w, r)
+	})
+	http.HandleFunc("/comment/like", func(w http.ResponseWriter, r *http.Request) {
+		like(w, r)
+	})
+	http.HandleFunc("/comment/delete", func(w http.ResponseWriter, r *http.Request) {
+		delete(w, r)
+	})
+	http.HandleFunc("/comment/get", func(w http.ResponseWriter, r *http.Request) {
+		get(w, r)
+	})
+
+	http.ListenAndServe(":8080", nil)
+}

--- a/comments/User.go
+++ b/comments/User.go
@@ -1,0 +1,8 @@
+package main
+
+//User class, handles if they are authorized and contains info for comments
+
+type user struct {
+	id    string `json:"user"`
+	token string `json:"token"`
+}


### PR DESCRIPTION
Self.go listens and passes things onto Comment.go.

Comment.go is supposed to provide most of the basic comment functionality.

SQL.go is supposed to make database interaction easier, but might be redundant.

User.go is supposed to provide some basic functionality, like session checking and such.